### PR TITLE
URSA-7914 | defer local SDP publication until useful ICE candidates are available

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -15,6 +15,7 @@ import 'name_addr_header.dart';
 import 'request_sender.dart';
 import 'rtc_session/dtmf.dart' as RTCSession_DTMF;
 import 'rtc_session/dtmf.dart';
+import 'rtc_session/ice_summary.dart';
 import 'rtc_session/info.dart' as RTCSession_Info;
 import 'rtc_session/info.dart';
 import 'rtc_session/refer_notifier.dart';
@@ -48,202 +49,6 @@ const Duration kIceRestartRetryWindow = Duration(seconds: 180);
 const Duration kIceRestartDebounce = Duration(seconds: 3);
 
 const Duration kIceCandidateSettleDelay = Duration(milliseconds: 250);
-
-class _IceServerSummary {
-  _IceServerSummary({
-    required this.count,
-    required this.stunConfigured,
-    required this.turnConfigured,
-  });
-
-  factory _IceServerSummary.fromPcConfig(Map<String, dynamic>? pcConfig) {
-    dynamic configuredServers = pcConfig?['iceServers'];
-    List<dynamic> servers = configuredServers is Iterable
-        ? configuredServers.toList()
-        : configuredServers == null
-            ? <dynamic>[]
-            : <dynamic>[configuredServers];
-    bool stunConfigured = false;
-    bool turnConfigured = false;
-
-    for (dynamic server in servers) {
-      dynamic configuredUrls = server is Map
-          ? server['urls'] ?? server['url']
-          : server;
-      List<dynamic> urls = configuredUrls is Iterable && configuredUrls is! String
-          ? configuredUrls.toList()
-          : configuredUrls == null
-              ? <dynamic>[]
-              : <dynamic>[configuredUrls];
-      for (dynamic value in urls) {
-        String url = value.toString().toLowerCase();
-        stunConfigured =
-            stunConfigured || url.startsWith('stun:') || url.startsWith('stuns:');
-        turnConfigured =
-            turnConfigured || url.startsWith('turn:') || url.startsWith('turns:');
-      }
-    }
-
-    return _IceServerSummary(
-      count: servers.length,
-      stunConfigured: stunConfigured,
-      turnConfigured: turnConfigured,
-    );
-  }
-
-  final int count;
-  final bool stunConfigured;
-  final bool turnConfigured;
-
-  String get logFields =>
-      'iceServerCount=$count stunConfigured=$stunConfigured '
-      'turnConfigured=$turnConfigured';
-}
-
-class _IceSdpSummary {
-  _IceSdpSummary({
-    required this.total,
-    required this.host,
-    required this.srflx,
-    required this.relay,
-    required this.prflx,
-    required this.unknown,
-    required this.udp,
-    required this.tcp,
-    required this.unknownProtocol,
-    required this.candidatesByMid,
-  });
-
-  factory _IceSdpSummary.fromSdp(String? sdp) {
-    int total = 0;
-    int host = 0;
-    int srflx = 0;
-    int relay = 0;
-    int prflx = 0;
-    int unknown = 0;
-    int udp = 0;
-    int tcp = 0;
-    int unknownProtocol = 0;
-    int currentMediaSection = -1;
-    int sessionLevelCandidates = 0;
-    List<int> candidateCountsBySection = <int>[];
-    List<String?> midsBySection = <String?>[];
-    Map<String, int> candidatesByMid = <String, int>{};
-
-    for (String rawLine in (sdp ?? '').split(RegExp(r'\r?\n'))) {
-      String line = rawLine.trim();
-      if (line.startsWith('m=')) {
-        currentMediaSection += 1;
-        candidateCountsBySection.add(0);
-        midsBySection.add(null);
-        continue;
-      }
-      if (line.startsWith('a=mid:')) {
-        if (currentMediaSection >= 0) {
-          midsBySection[currentMediaSection] =
-              line.substring('a=mid:'.length);
-        }
-        continue;
-      }
-      if (!line.startsWith('a=candidate:')) {
-        continue;
-      }
-
-      total += 1;
-      if (currentMediaSection >= 0) {
-        candidateCountsBySection[currentMediaSection] += 1;
-      } else {
-        sessionLevelCandidates += 1;
-      }
-      switch (candidateType(line)) {
-        case 'host':
-          host += 1;
-          break;
-        case 'srflx':
-          srflx += 1;
-          break;
-        case 'relay':
-          relay += 1;
-          break;
-        case 'prflx':
-          prflx += 1;
-          break;
-        default:
-          unknown += 1;
-      }
-      switch (candidateProtocol(line)) {
-        case 'udp':
-          udp += 1;
-          break;
-        case 'tcp':
-          tcp += 1;
-          break;
-        default:
-          unknownProtocol += 1;
-      }
-    }
-
-    if (sessionLevelCandidates > 0) {
-      candidatesByMid['none'] = sessionLevelCandidates;
-    }
-    for (int index = 0; index < candidateCountsBySection.length; index += 1) {
-      int count = candidateCountsBySection[index];
-      if (count == 0) {
-        continue;
-      }
-      String? mid = midsBySection[index];
-      String key = mid == null || mid.isEmpty ? 'm$index' : mid;
-      candidatesByMid[key] = (candidatesByMid[key] ?? 0) + count;
-    }
-
-    return _IceSdpSummary(
-      total: total,
-      host: host,
-      srflx: srflx,
-      relay: relay,
-      prflx: prflx,
-      unknown: unknown,
-      udp: udp,
-      tcp: tcp,
-      unknownProtocol: unknownProtocol,
-      candidatesByMid: candidatesByMid,
-    );
-  }
-
-  static final RegExp _candidateTypePattern =
-      RegExp(r'(?:^|\s)typ\s+(host|srflx|relay|prflx)(?:\s|$)');
-  static final RegExp _candidateProtocolPattern =
-      RegExp(r'^(?:a=)?candidate:\S+\s+\S+\s+(udp|tcp)(?:\s|$)',
-          caseSensitive: false);
-
-  static String candidateType(String? candidate) {
-    RegExpMatch? match =
-        _candidateTypePattern.firstMatch(candidate ?? '');
-    return match?.group(1) ?? 'unknown';
-  }
-
-  static String candidateProtocol(String? candidate) {
-    RegExpMatch? match =
-        _candidateProtocolPattern.firstMatch(candidate ?? '');
-    return match?.group(1)?.toLowerCase() ?? 'unknown';
-  }
-
-  final int total;
-  final int host;
-  final int srflx;
-  final int relay;
-  final int prflx;
-  final int unknown;
-  final int udp;
-  final int tcp;
-  final int unknownProtocol;
-  final Map<String, int> candidatesByMid;
-
-  String get logFields =>
-      'total=$total host=$host srflx=$srflx relay=$relay '
-      'prflx=$prflx unknown=$unknown udp=$udp tcp=$tcp '
-      'unknownProtocol=$unknownProtocol mids=$candidatesByMid';
-}
 
 class SIPTimers {
   Timer? ackTimer;
@@ -2026,8 +1831,8 @@ class RTCSession extends EventManager implements Owner {
     _pcConfig = Map<String, dynamic>.from(pcConfig);
     _rtcConstraints = Map<String, dynamic>.from(rtcConstraints);
 
-    _IceServerSummary iceServerSummary =
-        _IceServerSummary.fromPcConfig(pcConfig);
+    IceServerSummary iceServerSummary =
+        IceServerSummary.fromPcConfig(pcConfig);
     logger.i('createPeerConnection | creating RTCPeerConnection');
     logger.i(
         'peer_connection_constraints | ${iceServerSummary.logFields} '
@@ -2072,6 +1877,14 @@ class RTCSession extends EventManager implements Owner {
     logger.d('emit "peerconnection"');
     emit(EventPeerConnection(_connection));
     return;
+  }
+
+  String _callIdForLogging() {
+    try {
+      return _request?.call_id?.toString() ?? 'unknown';
+    } catch (_) {
+      return 'unknown';
+    }
   }
 
   Future<RTCSessionDescription> _createLocalDescription(
@@ -2129,16 +1942,8 @@ class RTCSession extends EventManager implements Owner {
     RTCPeerConnection connection = _connection!;
     Timer? iceCandidateSettleTimer;
     Future<void> readinessQueue = Future<void>.value();
-    _IceServerSummary iceServerSummary =
-        _IceServerSummary.fromPcConfig(_pcConfig);
-
-    String callId() {
-      try {
-        return _request?.call_id?.toString() ?? 'unknown';
-      } catch (_) {
-        return 'unknown';
-      }
-    }
+    IceServerSummary iceServerSummary =
+        IceServerSummary.fromPcConfig(_pcConfig);
 
     void cleanupIceGathering() {
       iceGatheringTimer?.cancel();
@@ -2167,7 +1972,7 @@ class RTCSession extends EventManager implements Owner {
         localDescription = await connection.getLocalDescription();
       } catch (error) {
         logger.w(
-            'local_description | decision=deferred callId=${callId()} '
+            'local_description | decision=deferred callId=${_callIdForLogging()} '
             'type=$type trigger=$trigger reason=description_read_failed '
             'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
             'errorType=${error.runtimeType}');
@@ -2177,14 +1982,14 @@ class RTCSession extends EventManager implements Owner {
       }
       if (localDescription == null) {
         logger.w(
-            'local_description | decision=deferred callId=${callId()} '
+            'local_description | decision=deferred callId=${_callIdForLogging()} '
             'type=$type trigger=$trigger reason=missing_description '
             'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds}');
         return;
       }
 
-      _IceSdpSummary summary =
-          _IceSdpSummary.fromSdp(localDescription.sdp);
+      IceSdpSummary summary =
+          IceSdpSummary.fromSdp(localDescription.sdp);
       String? deferredReason;
       if (!force && summary.total == 0) {
         deferredReason = 'no_candidates';
@@ -2198,7 +2003,7 @@ class RTCSession extends EventManager implements Owner {
 
       if (deferredReason != null) {
         logger.i(
-            'local_description | decision=deferred callId=${callId()} '
+            'local_description | decision=deferred callId=${_callIdForLogging()} '
             'type=$type trigger=$trigger reason=$deferredReason '
             'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
             'turnConfigured=${iceServerSummary.turnConfigured} '
@@ -2211,7 +2016,7 @@ class RTCSession extends EventManager implements Owner {
       _iceGatheringState = RTCIceGatheringState.RTCIceGatheringStateComplete;
       _rtcReady = true;
       logger.i(
-          'local_description | decision=ready callId=${callId()} type=$type '
+          'local_description | decision=ready callId=${_callIdForLogging()} type=$type '
           'trigger=$trigger elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
           'turnConfigured=${iceServerSummary.turnConfigured} '
           'callbacks=$candidateCallbacksBeforeReady ${summary.logFields}');
@@ -2280,11 +2085,11 @@ class RTCSession extends EventManager implements Owner {
         if (candidate != null) {
           candidateCallbacksBeforeReady += 1;
           logger.i(
-              'ice_candidate | callId=${callId()} '
+              'ice_candidate | callId=${_callIdForLogging()} '
               'sequence=$candidateCallbacksBeforeReady '
               'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
-              'type=${_IceSdpSummary.candidateType(candidate.candidate)} '
-              'protocol=${_IceSdpSummary.candidateProtocol(candidate.candidate)} '
+              'type=${IceSdpSummary.candidateType(candidate.candidate)} '
+              'protocol=${IceSdpSummary.candidateProtocol(candidate.candidate)} '
               'sdpMid=${candidate.sdpMid} '
               'sdpMLineIndex=${candidate.sdpMLineIndex}');
           emit(EventIceCandidate(candidate, requestReadyAfterSettle));

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -47,6 +47,204 @@ const List<String?> holdMediaTypes = <String?>['audio', 'video'];
 const Duration kIceRestartRetryWindow = Duration(seconds: 180);
 const Duration kIceRestartDebounce = Duration(seconds: 3);
 
+const Duration kIceCandidateSettleDelay = Duration(milliseconds: 250);
+
+class _IceServerSummary {
+  _IceServerSummary({
+    required this.count,
+    required this.stunConfigured,
+    required this.turnConfigured,
+  });
+
+  factory _IceServerSummary.fromPcConfig(Map<String, dynamic>? pcConfig) {
+    dynamic configuredServers = pcConfig?['iceServers'];
+    List<dynamic> servers = configuredServers is Iterable
+        ? configuredServers.toList()
+        : configuredServers == null
+            ? <dynamic>[]
+            : <dynamic>[configuredServers];
+    bool stunConfigured = false;
+    bool turnConfigured = false;
+
+    for (dynamic server in servers) {
+      dynamic configuredUrls = server is Map
+          ? server['urls'] ?? server['url']
+          : server;
+      List<dynamic> urls = configuredUrls is Iterable && configuredUrls is! String
+          ? configuredUrls.toList()
+          : configuredUrls == null
+              ? <dynamic>[]
+              : <dynamic>[configuredUrls];
+      for (dynamic value in urls) {
+        String url = value.toString().toLowerCase();
+        stunConfigured =
+            stunConfigured || url.startsWith('stun:') || url.startsWith('stuns:');
+        turnConfigured =
+            turnConfigured || url.startsWith('turn:') || url.startsWith('turns:');
+      }
+    }
+
+    return _IceServerSummary(
+      count: servers.length,
+      stunConfigured: stunConfigured,
+      turnConfigured: turnConfigured,
+    );
+  }
+
+  final int count;
+  final bool stunConfigured;
+  final bool turnConfigured;
+
+  String get logFields =>
+      'iceServerCount=$count stunConfigured=$stunConfigured '
+      'turnConfigured=$turnConfigured';
+}
+
+class _IceSdpSummary {
+  _IceSdpSummary({
+    required this.total,
+    required this.host,
+    required this.srflx,
+    required this.relay,
+    required this.prflx,
+    required this.unknown,
+    required this.udp,
+    required this.tcp,
+    required this.unknownProtocol,
+    required this.candidatesByMid,
+  });
+
+  factory _IceSdpSummary.fromSdp(String? sdp) {
+    int total = 0;
+    int host = 0;
+    int srflx = 0;
+    int relay = 0;
+    int prflx = 0;
+    int unknown = 0;
+    int udp = 0;
+    int tcp = 0;
+    int unknownProtocol = 0;
+    int currentMediaSection = -1;
+    int sessionLevelCandidates = 0;
+    List<int> candidateCountsBySection = <int>[];
+    List<String?> midsBySection = <String?>[];
+    Map<String, int> candidatesByMid = <String, int>{};
+
+    for (String rawLine in (sdp ?? '').split(RegExp(r'\r?\n'))) {
+      String line = rawLine.trim();
+      if (line.startsWith('m=')) {
+        currentMediaSection += 1;
+        candidateCountsBySection.add(0);
+        midsBySection.add(null);
+        continue;
+      }
+      if (line.startsWith('a=mid:')) {
+        if (currentMediaSection >= 0) {
+          midsBySection[currentMediaSection] =
+              line.substring('a=mid:'.length);
+        }
+        continue;
+      }
+      if (!line.startsWith('a=candidate:')) {
+        continue;
+      }
+
+      total += 1;
+      if (currentMediaSection >= 0) {
+        candidateCountsBySection[currentMediaSection] += 1;
+      } else {
+        sessionLevelCandidates += 1;
+      }
+      switch (candidateType(line)) {
+        case 'host':
+          host += 1;
+          break;
+        case 'srflx':
+          srflx += 1;
+          break;
+        case 'relay':
+          relay += 1;
+          break;
+        case 'prflx':
+          prflx += 1;
+          break;
+        default:
+          unknown += 1;
+      }
+      switch (candidateProtocol(line)) {
+        case 'udp':
+          udp += 1;
+          break;
+        case 'tcp':
+          tcp += 1;
+          break;
+        default:
+          unknownProtocol += 1;
+      }
+    }
+
+    if (sessionLevelCandidates > 0) {
+      candidatesByMid['none'] = sessionLevelCandidates;
+    }
+    for (int index = 0; index < candidateCountsBySection.length; index += 1) {
+      int count = candidateCountsBySection[index];
+      if (count == 0) {
+        continue;
+      }
+      String? mid = midsBySection[index];
+      String key = mid == null || mid.isEmpty ? 'm$index' : mid;
+      candidatesByMid[key] = (candidatesByMid[key] ?? 0) + count;
+    }
+
+    return _IceSdpSummary(
+      total: total,
+      host: host,
+      srflx: srflx,
+      relay: relay,
+      prflx: prflx,
+      unknown: unknown,
+      udp: udp,
+      tcp: tcp,
+      unknownProtocol: unknownProtocol,
+      candidatesByMid: candidatesByMid,
+    );
+  }
+
+  static final RegExp _candidateTypePattern =
+      RegExp(r'(?:^|\s)typ\s+(host|srflx|relay|prflx)(?:\s|$)');
+  static final RegExp _candidateProtocolPattern =
+      RegExp(r'^(?:a=)?candidate:\S+\s+\S+\s+(udp|tcp)(?:\s|$)',
+          caseSensitive: false);
+
+  static String candidateType(String? candidate) {
+    RegExpMatch? match =
+        _candidateTypePattern.firstMatch(candidate ?? '');
+    return match?.group(1) ?? 'unknown';
+  }
+
+  static String candidateProtocol(String? candidate) {
+    RegExpMatch? match =
+        _candidateProtocolPattern.firstMatch(candidate ?? '');
+    return match?.group(1)?.toLowerCase() ?? 'unknown';
+  }
+
+  final int total;
+  final int host;
+  final int srflx;
+  final int relay;
+  final int prflx;
+  final int unknown;
+  final int udp;
+  final int tcp;
+  final int unknownProtocol;
+  final Map<String, int> candidatesByMid;
+
+  String get logFields =>
+      'total=$total host=$host srflx=$srflx relay=$relay '
+      'prflx=$prflx unknown=$unknown udp=$udp tcp=$tcp '
+      'unknownProtocol=$unknownProtocol mids=$candidatesByMid';
+}
+
 class SIPTimers {
   Timer? ackTimer;
   Timer? expiresTimer;
@@ -1828,9 +2026,12 @@ class RTCSession extends EventManager implements Owner {
     _pcConfig = Map<String, dynamic>.from(pcConfig);
     _rtcConstraints = Map<String, dynamic>.from(rtcConstraints);
 
+    _IceServerSummary iceServerSummary =
+        _IceServerSummary.fromPcConfig(pcConfig);
     logger.i('createPeerConnection | creating RTCPeerConnection');
     logger.i(
-        'peer_connection_constraints | pcConfig=$pcConfig rtcConstraints=$rtcConstraints');
+        'peer_connection_constraints | ${iceServerSummary.logFields} '
+        'sdpSemantics=${pcConfig['sdpSemantics'] ?? 'unified-plan'}');
 
     try {
       _connection = await createPeerConnection(pcConfig, rtcConstraints);
@@ -1923,27 +2124,120 @@ class RTCSession extends EventManager implements Owner {
 
     // Add 'pc.onicencandidate' event handler to resolve on last candidate.
     bool finished = false;
+    int candidateCallbacksBeforeReady = 0;
+    Stopwatch iceGatheringStopwatch = Stopwatch();
+    RTCPeerConnection connection = _connection!;
+    Timer? iceCandidateSettleTimer;
+    Future<void> readinessQueue = Future<void>.value();
+    _IceServerSummary iceServerSummary =
+        _IceServerSummary.fromPcConfig(_pcConfig);
+
+    String callId() {
+      try {
+        return _request?.call_id?.toString() ?? 'unknown';
+      } catch (_) {
+        return 'unknown';
+      }
+    }
+
+    void cleanupIceGathering() {
+      iceGatheringTimer?.cancel();
+      iceCandidateSettleTimer?.cancel();
+      connection.onIceCandidate = null;
+      connection.onIceGatheringState = null;
+    }
 
     for (Future<RTCSessionDescription> Function(RTCSessionDescription) modifier
         in modifiers) {
       desc = await modifier(desc);
     }
 
-    Future<void> ready() async {
-      logger.i(
-          'local_description | ready iceGatheringState=$_iceGatheringState');
-      iceGatheringTimer?.cancel();
-      if (!finished && _status != C.STATUS_TERMINATED) {
-        finished = true;
-        _connection!.onIceCandidate = null;
-        _connection!.onIceGatheringState = null;
-        _iceGatheringState = RTCIceGatheringState.RTCIceGatheringStateComplete;
-        _rtcReady = true;
-        RTCSessionDescription? desc = await _connection!.getLocalDescription();
-        logger.d('emit "sdp"');
-        emit(EventSdp(originator: 'local', type: type, sdp: desc!.sdp));
-        completer.complete(desc);
+    Future<void> evaluateReadiness(String trigger,
+        {bool force = false, bool allowReady = true}) async {
+      if (finished) {
+        return;
       }
+      if (_status == C.STATUS_TERMINATED) {
+        cleanupIceGathering();
+        return;
+      }
+
+      RTCSessionDescription? localDescription;
+      try {
+        localDescription = await connection.getLocalDescription();
+      } catch (error) {
+        logger.w(
+            'local_description | decision=deferred callId=${callId()} '
+            'type=$type trigger=$trigger reason=description_read_failed '
+            'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
+            'errorType=${error.runtimeType}');
+      }
+      if (localDescription == null && force) {
+        localDescription = desc;
+      }
+      if (localDescription == null) {
+        logger.w(
+            'local_description | decision=deferred callId=${callId()} '
+            'type=$type trigger=$trigger reason=missing_description '
+            'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds}');
+        return;
+      }
+
+      _IceSdpSummary summary =
+          _IceSdpSummary.fromSdp(localDescription.sdp);
+      String? deferredReason;
+      if (!force && summary.total == 0) {
+        deferredReason = 'no_candidates';
+      } else if (!force &&
+          iceServerSummary.turnConfigured &&
+          summary.relay == 0) {
+        deferredReason = 'relay_pending';
+      } else if (!force && !allowReady) {
+        deferredReason = 'settling';
+      }
+
+      if (deferredReason != null) {
+        logger.i(
+            'local_description | decision=deferred callId=${callId()} '
+            'type=$type trigger=$trigger reason=$deferredReason '
+            'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
+            'turnConfigured=${iceServerSummary.turnConfigured} '
+            'callbacks=$candidateCallbacksBeforeReady ${summary.logFields}');
+        return;
+      }
+
+      finished = true;
+      cleanupIceGathering();
+      _iceGatheringState = RTCIceGatheringState.RTCIceGatheringStateComplete;
+      _rtcReady = true;
+      logger.i(
+          'local_description | decision=ready callId=${callId()} type=$type '
+          'trigger=$trigger elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
+          'turnConfigured=${iceServerSummary.turnConfigured} '
+          'callbacks=$candidateCallbacksBeforeReady ${summary.logFields}');
+      logger.d('emit "sdp"');
+      emit(EventSdp(
+          originator: 'local', type: type, sdp: localDescription.sdp));
+      if (!completer.isCompleted) {
+        completer.complete(localDescription);
+      }
+    }
+
+    Future<void> requestReadinessEvaluation(String trigger,
+        {bool force = false, bool allowReady = true}) {
+      readinessQueue = readinessQueue.then((_) => evaluateReadiness(trigger,
+          force: force, allowReady: allowReady));
+      return readinessQueue;
+    }
+
+    Future<void> requestReadyAfterSettle() async {
+      if (finished || _status == C.STATUS_TERMINATED) {
+        return;
+      }
+      iceCandidateSettleTimer?.cancel();
+      iceCandidateSettleTimer = Timer(kIceCandidateSettleDelay, () {
+        requestReadinessEvaluation('settled');
+      });
     }
 
     void startIceGatheringTimer() {
@@ -1957,16 +2251,21 @@ class RTCSession extends EventManager implements Owner {
 
       logger.d(
           'startIceGatheringTimer() | creating new timer for ${ua.configuration.ice_gathering_timeout} milliseconds');
-      iceGatheringTimer =
-          setTimeout(() => ready(), ua.configuration.ice_gathering_timeout);
+      iceGatheringTimer = setTimeout(() {
+        requestReadinessEvaluation('timeout', force: true);
+      }, ua.configuration.ice_gathering_timeout);
     }
 
-    _connection!.onIceGatheringState = (RTCIceGatheringState state) {
+    connection.onIceGatheringState = (RTCIceGatheringState state) {
       try {
         _iceGatheringState = state;
         logger.i('ice_gathering_state | state=$state');
         if (state == RTCIceGatheringState.RTCIceGatheringStateComplete) {
-          ready();
+          requestReadinessEvaluation('complete',
+              allowReady: !iceServerSummary.turnConfigured);
+          if (iceServerSummary.turnConfigured) {
+            requestReadyAfterSettle();
+          }
         }
       } catch (error, stacktrace) {
         logger.e(
@@ -1976,16 +2275,20 @@ class RTCSession extends EventManager implements Owner {
       }
     };
 
-    bool hasCandidate = false;
-    _connection!.onIceCandidate = (RTCIceCandidate candidate) {
+    connection.onIceCandidate = (RTCIceCandidate candidate) {
       try {
         if (candidate != null) {
+          candidateCallbacksBeforeReady += 1;
           logger.i(
-              'ice_candidate | sdpMid=${candidate.sdpMid} sdpMLineIndex=${candidate.sdpMLineIndex}');
-          emit(EventIceCandidate(candidate, ready));
-          if (!hasCandidate) {
-            hasCandidate = true;
-          }
+              'ice_candidate | callId=${callId()} '
+              'sequence=$candidateCallbacksBeforeReady '
+              'elapsedMs=${iceGatheringStopwatch.elapsedMilliseconds} '
+              'type=${_IceSdpSummary.candidateType(candidate.candidate)} '
+              'protocol=${_IceSdpSummary.candidateProtocol(candidate.candidate)} '
+              'sdpMid=${candidate.sdpMid} '
+              'sdpMLineIndex=${candidate.sdpMLineIndex}');
+          emit(EventIceCandidate(candidate, requestReadyAfterSettle));
+          requestReadyAfterSettle();
         }
       } catch (error, stacktrace) {
         logger.e(
@@ -1996,30 +2299,33 @@ class RTCSession extends EventManager implements Owner {
     };
 
     try {
-      await _connection!.setLocalDescription(desc);
+      iceGatheringStopwatch.start();
+      await connection.setLocalDescription(desc);
       logger.i('local_description | setLocalDescription success type=$type');
     } catch (error) {
       _rtcReady = true;
-      iceGatheringTimer?.cancel();
-      _connection!.onIceCandidate = null;
-      _connection!.onIceGatheringState = null;
+      cleanupIceGathering();
       logger.i('local_description | setLocalDescription failed type=$type');
       logger.e(
           'emit "peerconnection:setlocaldescriptionfailed" [error:${error.toString()}]');
       emit(EventSetLocalDescriptionFailed(exception: error));
       completer.completeError(error);
+      return completer.future;
     }
 
-    // Resolve right away if 'pc.iceGatheringState' is 'complete'.
+    if (!finished && !completer.isCompleted) {
+      startIceGatheringTimer();
+    }
+
+    // Use the same readiness checks if gathering completed before
+    // setLocalDescription returned.
     if (_iceGatheringState ==
         RTCIceGatheringState.RTCIceGatheringStateComplete) {
-      _rtcReady = true;
-      RTCSessionDescription? desc = await _connection!.getLocalDescription();
-      logger.d('emit "sdp"');
-      emit(EventSdp(originator: 'local', type: type, sdp: desc!.sdp));
-      return desc;
-    } else {
-      startIceGatheringTimer();
+      requestReadinessEvaluation('complete',
+          allowReady: !iceServerSummary.turnConfigured);
+      if (iceServerSummary.turnConfigured) {
+        requestReadyAfterSettle();
+      }
     }
 
     return completer.future;

--- a/lib/src/rtc_session/ice_summary.dart
+++ b/lib/src/rtc_session/ice_summary.dart
@@ -1,0 +1,195 @@
+class IceServerSummary {
+  IceServerSummary({
+    required this.count,
+    required this.stunConfigured,
+    required this.turnConfigured,
+  });
+
+  factory IceServerSummary.fromPcConfig(Map<String, dynamic>? pcConfig) {
+    dynamic configuredServers = pcConfig?['iceServers'];
+    List<dynamic> servers = configuredServers is Iterable
+        ? configuredServers.toList()
+        : configuredServers == null
+            ? <dynamic>[]
+            : <dynamic>[configuredServers];
+    bool stunConfigured = false;
+    bool turnConfigured = false;
+
+    for (dynamic server in servers) {
+      dynamic configuredUrls = server is Map
+          ? server['urls'] ?? server['url']
+          : server;
+      List<dynamic> urls = configuredUrls is Iterable && configuredUrls is! String
+          ? configuredUrls.toList()
+          : configuredUrls == null
+              ? <dynamic>[]
+              : <dynamic>[configuredUrls];
+      for (dynamic value in urls) {
+        String url = value.toString().toLowerCase();
+        stunConfigured =
+            stunConfigured || url.startsWith('stun:') || url.startsWith('stuns:');
+        turnConfigured =
+            turnConfigured || url.startsWith('turn:') || url.startsWith('turns:');
+      }
+    }
+
+    return IceServerSummary(
+      count: servers.length,
+      stunConfigured: stunConfigured,
+      turnConfigured: turnConfigured,
+    );
+  }
+
+  final int count;
+  final bool stunConfigured;
+  final bool turnConfigured;
+
+  String get logFields =>
+      'iceServerCount=$count stunConfigured=$stunConfigured '
+      'turnConfigured=$turnConfigured';
+}
+
+class IceSdpSummary {
+  IceSdpSummary({
+    required this.total,
+    required this.host,
+    required this.srflx,
+    required this.relay,
+    required this.prflx,
+    required this.unknown,
+    required this.udp,
+    required this.tcp,
+    required this.unknownProtocol,
+    required this.candidatesByMid,
+  });
+
+  factory IceSdpSummary.fromSdp(String? sdp) {
+    int total = 0;
+    int host = 0;
+    int srflx = 0;
+    int relay = 0;
+    int prflx = 0;
+    int unknown = 0;
+    int udp = 0;
+    int tcp = 0;
+    int unknownProtocol = 0;
+    int currentMediaSection = -1;
+    int sessionLevelCandidates = 0;
+    List<int> candidateCountsBySection = <int>[];
+    List<String?> midsBySection = <String?>[];
+    Map<String, int> candidatesByMid = <String, int>{};
+
+    for (String rawLine in (sdp ?? '').split(RegExp(r'\r?\n'))) {
+      String line = rawLine.trim();
+      if (line.startsWith('m=')) {
+        currentMediaSection += 1;
+        candidateCountsBySection.add(0);
+        midsBySection.add(null);
+        continue;
+      }
+      if (line.startsWith('a=mid:')) {
+        if (currentMediaSection >= 0) {
+          midsBySection[currentMediaSection] =
+              line.substring('a=mid:'.length);
+        }
+        continue;
+      }
+      if (!line.startsWith('a=candidate:')) {
+        continue;
+      }
+
+      total += 1;
+      if (currentMediaSection >= 0) {
+        candidateCountsBySection[currentMediaSection] += 1;
+      } else {
+        sessionLevelCandidates += 1;
+      }
+      switch (candidateType(line)) {
+        case 'host':
+          host += 1;
+          break;
+        case 'srflx':
+          srflx += 1;
+          break;
+        case 'relay':
+          relay += 1;
+          break;
+        case 'prflx':
+          prflx += 1;
+          break;
+        default:
+          unknown += 1;
+      }
+      switch (candidateProtocol(line)) {
+        case 'udp':
+          udp += 1;
+          break;
+        case 'tcp':
+          tcp += 1;
+          break;
+        default:
+          unknownProtocol += 1;
+      }
+    }
+
+    if (sessionLevelCandidates > 0) {
+      candidatesByMid['none'] = sessionLevelCandidates;
+    }
+    for (int index = 0; index < candidateCountsBySection.length; index += 1) {
+      int count = candidateCountsBySection[index];
+      if (count == 0) {
+        continue;
+      }
+      String? mid = midsBySection[index];
+      String key = mid == null || mid.isEmpty ? 'm$index' : mid;
+      candidatesByMid[key] = (candidatesByMid[key] ?? 0) + count;
+    }
+
+    return IceSdpSummary(
+      total: total,
+      host: host,
+      srflx: srflx,
+      relay: relay,
+      prflx: prflx,
+      unknown: unknown,
+      udp: udp,
+      tcp: tcp,
+      unknownProtocol: unknownProtocol,
+      candidatesByMid: candidatesByMid,
+    );
+  }
+
+  static final RegExp _candidateTypePattern =
+      RegExp(r'(?:^|\s)typ\s+(host|srflx|relay|prflx)(?:\s|$)');
+  static final RegExp _candidateProtocolPattern =
+      RegExp(r'^(?:a=)?candidate:\S+\s+\S+\s+(udp|tcp)(?:\s|$)',
+          caseSensitive: false);
+
+  static String candidateType(String? candidate) {
+    RegExpMatch? match =
+        _candidateTypePattern.firstMatch(candidate ?? '');
+    return match?.group(1) ?? 'unknown';
+  }
+
+  static String candidateProtocol(String? candidate) {
+    RegExpMatch? match =
+        _candidateProtocolPattern.firstMatch(candidate ?? '');
+    return match?.group(1)?.toLowerCase() ?? 'unknown';
+  }
+
+  final int total;
+  final int host;
+  final int srflx;
+  final int relay;
+  final int prflx;
+  final int unknown;
+  final int udp;
+  final int tcp;
+  final int unknownProtocol;
+  final Map<String, int> candidatesByMid;
+
+  String get logFields =>
+      'total=$total host=$host srflx=$srflx relay=$relay '
+      'prflx=$prflx unknown=$unknown udp=$udp tcp=$tcp '
+      'unknownProtocol=$unknownProtocol mids=$candidatesByMid';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sip_ua
-version: 1.17.0
+version: 1.18.0
 description: A SIP UA stack for Flutter/Dart, based on flutter-webrtc, support iOS/Android/Destkop/Web.
 homepage: https://github.com/cloudwebrtc/dart-sip-ua
 environment:


### PR DESCRIPTION
## Summary

This PR hardens ICE gathering in `rtc_session.dart` against an Android/flutter_webrtc callback-ordering race.

`RTCIceGatheringStateComplete` is no longer sufficient by itself to publish the local SDP. The implementation now evaluates the candidates actually present in `localDescription`, waits briefly for queued candidate callbacks, and prefers a relay candidate when TURN is configured.

TURN remains optional: if no relay candidate is produced before `iceGatheringTimeout`, the best available SDP is published.

## Context

This issue was reproduced while accepting incoming calls from a full-screen intent with the application terminated or the device locked.

The application accepted the SIP call and displayed the Connecting screen, but FreeSWITCH later terminated the call because the SDP answer did not contain any reachable ICE candidates.

The problem became more reproducible after HighlanderSDK began accepting the call earlier in the cold-start flow. That exposed ICE gathering before the UI was fully initialized and reduced the incidental delay that had previously hidden the race.

## Findings

Temporary SDP diagnostics showed the following sequence on failed calls:

1. `setLocalDescription` completed.
2. flutter_webrtc emitted `RTCIceGatheringStateComplete`.
3. The current local SDP contained zero candidates, or only host candidates.
4. dart-sip-ua immediately published that SDP.
5. `onIceCandidate` callbacks delivered host, srflx, and relay candidates a few milliseconds later.
6. Those candidates were too late because the SIP answer had already been sent.

FreeSWITCH logs confirmed that at least one failed call was terminated because the application did not provide a reachable ICE candidate.

Successful calls contained host, srflx, and relay candidates in the SDP answer.

This does not appear to be specific to Cloudflare TURN. The Cloudflare STUN+TURN configuration made the timing visible, but the underlying issue is that the ICE gathering state callback and candidate callbacks are not observed in a reliable publication order on this platform.

## Root cause

The previous implementation treated `RTCIceGatheringStateComplete` as definitive and immediately completed local SDP creation.

On Android/flutter_webrtc, the COMPLETE state callback may be observed before queued `onIceCandidate` callbacks have been processed and before the candidates are visible in `localDescription`.

As a result, dart-sip-ua could:

- Publish an SDP with no candidates.
- Remove or replace the ICE listeners.
- Ignore candidates delivered immediately afterward.
- Produce a SIP answer that could not establish a media path.

## Solution

All `_createLocalDescription()` completion paths now use the same guarded evaluation logic.

The new behavior is:

- Start the existing `iceGatheringTimeout` after `setLocalDescription`.
- Read the current local SDP whenever gathering completion is evaluated.
- Defer publication if the SDP has no candidates.
- If TURN is not configured, publish once useful candidates have settled.
- If TURN is configured, wait preferentially for at least one relay candidate.
- Restart a 250 ms settling window after every candidate callback.
- Publish after the settling window once the candidate requirements are satisfied.
- If no relay candidate appears, wait until `iceGatheringTimeout` and publish the best SDP available.
- Preserve the existing timeout contract, including the ability to publish an SDP with no candidates as a final fallback.
- Guard against concurrent evaluation and duplicate SDP emission.
- Cancel gathering and settling timers and listeners when negotiation completes, fails, or the session terminates.
- Apply the same logic when the peer connection already reports COMPLETE immediately after `setLocalDescription`.

TURN is intentionally preferred rather than required. A call with valid host or STUN-derived srflx candidates can still succeed if TURN is unavailable.

## Production observability

The temporary raw-SDP instrumentation was removed.

The retained logs contain only sanitized ICE metadata:

- Call ID and elapsed time.
- Publication trigger and decision.
- Deferred reason:
  - `no_candidates`
  - `relay_pending`
  - `settling`
- Candidate counts by type:
  - host
  - srflx
  - relay
  - prflx
  - unknown
- Candidate counts by protocol and `sdpMid`.
- Whether STUN and TURN are configured.

The logs do not include:

- Full SDP.
- IP addresses or ports.
- ICE foundations.
- ICE usernames, passwords, credentials, or ufrag values.

## Validation

A manual run included 8 incoming calls across 6 application processes, including cold starts.

Results:

- 8/8 peer connections were configured with STUN and TURN.
- 8/8 calls reached SIP Connected.
- 8/8 calls reached ICE Connected.
- 4 calls reported COMPLETE while the SDP still had zero candidates.
- 1 call reported COMPLETE with only host candidates and no relay.
- All 5 calls were deferred by the new logic.
- Their final SDP summaries contained:
  - 2 host candidates
  - 2 srflx candidates
  - 3–4 relay candidates
- All local descriptions were published through the settling path.
- No call required the ICE gathering timeout.

Without this change, the four zero-candidate cases would have published unusable SDP answers immediately at COMPLETE.